### PR TITLE
Fixed #18 - Backend: ver usuarios apuntados a una ponencia

### DIFF
--- a/src/Desymfony/DesymfonyBundle/Controller/AdminPonenciaController.php
+++ b/src/Desymfony/DesymfonyBundle/Controller/AdminPonenciaController.php
@@ -70,6 +70,19 @@ class AdminPonenciaController extends Controller
         ));
     }
     
+    public function showAction($id)
+    {
+        $peticion = $this->get('request');
+        $em = $this->get('doctrine.orm.entity_manager');
+        
+        if(null == $ponencia = $this->entidad('Ponencia')->findOneById($id)) {
+            throw new NotFoundHttpException('No existe la ponencia que se quiere ver');
+        }
+        
+        return $this->render('DesymfonyBundle:AdminPonencia:show.html.twig', array(
+            'ponencia'   => $ponencia
+        ));
+    }
     
     
     

--- a/src/Desymfony/DesymfonyBundle/Resources/config/admin_ponencia_routing.yml
+++ b/src/Desymfony/DesymfonyBundle/Resources/config/admin_ponencia_routing.yml
@@ -16,6 +16,6 @@ admin_ponencia_delete:
     defaults: { _controller: DesymfonyBundle:AdminPonencia:delete }
 
 admin_ponencia_apuntados:
-    pattern:  /{id}/apuntados
-    defaults: { _controller: DesymfonyBundle:AdminPonencia:apuntados }
+    pattern:  /show/{id}
+    defaults: { _controller: DesymfonyBundle:AdminPonencia:show }
 

--- a/src/Desymfony/DesymfonyBundle/Resources/views/AdminPonencia/show.html.twig
+++ b/src/Desymfony/DesymfonyBundle/Resources/views/AdminPonencia/show.html.twig
@@ -1,0 +1,44 @@
+{% extends "::admin_base.html.twig" %}
+
+{% block title %}Usuarios apuntados a la ponencia {{ ponencia.titulo }}{% endblock %}
+{% block pageid 'admin' %}
+
+{% block body %}
+<h1>Usuarios apuntados a la ponencia <em>{{ ponencia.titulo }}</em></h1>
+
+<ul>
+    <li><strong>Fecha</strong> {{ ponencia.fecha | date('d/m/Y H:i') }}</li>
+    <li><strong>Ponente</strong> {{ ponencia.ponente.nombre }} {{ ponencia.ponente.apellidos }}</li>
+    <li><strong>Duración</strong> {{ ponencia.duracion }}</li>
+    <li><strong>Idioma</strong> {{ idiomas[ponencia.idioma] }}</li>
+</ul>
+
+<table>
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>DNI</th>
+            <th>Nombre</th>
+            <th>Teléfono</th>
+            <th>Email</th>
+        </tr>
+    </thead>
+    
+    <tbody>
+        {% for usuario in ponencia.usuarios %}
+        <tr>
+            <td>{{ loop.index }}</td>
+            <td>{{ usuario.dni }}</td>
+            <td>{{ usuario.nombre }} {{ usuario.apellidos }} </td>
+            <td>{{ usuario.telefono }}</td>
+            <td>{{ usuario.email }}</td>
+        </tr>
+        {% else %}
+        <tr>
+            <td colspan="5">No hay ningún usuario apuntado</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+{% endblock %}


### PR DESCRIPTION
Se ha modificado la ruta prevista originalmente por una ruta más sencilla `/admin/show/{id}` en la que además de los usuarios apuntados, se muestra la información básica de la ponencia
