### PR TITLE
issue #94 - Custom error pages. + Corregido typo en README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Para probar mejor el proyecto, es muy recomendable cargar los datos de prueba
 (*fixtures*) de la aplicación ejecutando el siguiente comando:
 
 ```
-php /proyectos/desymfony/app/console doctrine:fixtures load
+php /proyectos/desymfony/app/console doctrine:fixtures:load
 ```
 
 El comando anterior crea varias ponencias y ponentes de prueba, 100 usuarios 

--- a/app/Resources/FrameworkBundle/views/Exception/error.html.twig
+++ b/app/Resources/FrameworkBundle/views/Exception/error.html.twig
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <title>Ocurrió un Error: {{ status_text }}</title>
+    </head>
+    <body>
+        <h1>Vaya! Ocurrió un Error</h1>
+        <h2>El servidor devolvió el siguiente error "{{ status_code }} {{ status_text }}".</h2>
+
+        {% if status_code == '404' %}
+        <div>
+           El archivo que buscabas no está en esta dirección, puede que hayas introducido incorrectamente la dirección, que el enlace que has seguido sea erróneo o que la página haya desaparecido. <br/><br/>
+           Si crees que se trata de un error, escríbenos a info@desymfony.com          
+        </div>
+        {% else %}
+       <div>
+           Ocurrió un error en la aplicación, algo está gravemente estropeado o estamos realizando tareas de mantenimiento.  Puedes intentar recargar la página, o repetir la acción que acabas de hacer. <br/><br/>
+           Si el problema persiste, escríbenos a info@desymfony.com
+        </div>
+
+        {% endif %}
+
+    </body>
+</html>


### PR DESCRIPTION
Sobreescrita la versión de error page por defecto, con un pequeño ajuste para que muestre un mensaje distinto si es error 404 u otro error. 

TODO: Decidir si conviene que extienda el layout general, al menos en el error 404. 
