### PR TITLE
[Fixes #43] Elimina firewall extra y crea pagina de error 403

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -1,10 +1,5 @@
 security:
     firewalls:
-        admin:
-            pattern:    ^/admin
-            http_basic: true
-            logout:     true
-            stateless:  true
         secured_area:
             pattern:    ^/
             anonymous:  ~
@@ -14,7 +9,7 @@ security:
             logout:
                 path:   /logoff
                 target: /
-                
+    access_denied_url: /denegado
     access_control:
         - { path: ^/perfil        , roles: ROLE_USER }
         - { path: ^/me-apunto-a-* , roles: ROLE_USER }
@@ -22,10 +17,6 @@ security:
         - { path: ^/registro      , roles: IS_AUTHENTICATED_ANONYMOUSLY }
 
     providers:
-#        in_memory:
-#            users:
-#                ryan:  { password: ryanpass, roles: 'ROLE_USER' }
-#                admin: { password: kitten, roles: 'ROLE_ADMIN' }
         main:
             providers: [in_memory, user_db]
         in_memory:

--- a/src/Desymfony/DesymfonyBundle/Controller/UsuarioController.php
+++ b/src/Desymfony/DesymfonyBundle/Controller/UsuarioController.php
@@ -28,16 +28,6 @@ class UsuarioController extends Controller
         ));
     }
 
-    public function loginCheckAction()
-    {
-        
-    }
-
-    public function logoffAction()
-    {
-        
-    }
-
     public function perfilAction()
     {
         $usuario = $this->get('security.context')->getToken()->getUser();
@@ -47,7 +37,7 @@ class UsuarioController extends Controller
     public function registroAction()
     {
         $form = $this->get('form.factory')->create(new UsuarioType(), array());
-        
+
         $request = $this->get('request');
         if ($request->getMethod() == 'POST') {
             $form->bindRequest($request);
@@ -72,5 +62,10 @@ class UsuarioController extends Controller
             }
         }
         return $this->render('DesymfonyBundle:Usuario:registro.html.twig', array('form' => $form->createView()));
+    }
+
+    public function denegadoAction()
+    {
+        return $this->render('DesymfonyBundle:Usuario:denegado.html.twig');
     }
 }

--- a/src/Desymfony/DesymfonyBundle/Resources/config/usuario_routing.yml
+++ b/src/Desymfony/DesymfonyBundle/Resources/config/usuario_routing.yml
@@ -16,3 +16,7 @@ login_check:
 logoff:
     pattern:  /logoff
     defaults: { _controller: DesymfonyBundle:Usuario:logoff }
+
+denegado:
+    pattern:  /denegado
+    defaults: { _controller: DesymfonyBundle:Usuario:denegado }

--- a/src/Desymfony/DesymfonyBundle/Resources/views/Usuario/denegado.html.twig
+++ b/src/Desymfony/DesymfonyBundle/Resources/views/Usuario/denegado.html.twig
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <title>Ocurrió un Error: 403</title>
+    </head>
+    <body>
+        <h1>Acceso Denegado</h1>
+
+        <div>
+           Se ha intentado acceder a una página para lo cual es necesario tener el permiso correspondiente (distinto del actual). <br/><br/>
+           Si crees que se trata de un error, escríbenos a info@desymfony.com
+        </div>
+
+    </body>
+</html>


### PR DESCRIPTION
- Elimina firewall extra
- Crea el url del error 403 con `access_denied_url:` en `security.yml`
- Crea la plantilla de `acesso denegado` basada en la plantilla de error del PR de @esmiz https://github.com/desymfony/desymfony/pull/95

El manejo del error 403 debe hacerse de diferente manera, usando `access_denied_url:` en `security.yml`:
https://groups.google.com/d/msg/symfony-users/aAv1OPcq-Mo/U31JR963KUIJ

Hubo un PR de Fabien, para arreglar el problema de la inconsistencia en el error con respecto a los demas, pero parece que es mas complejo de lo que se ve a simple vista, por que se cerro:
https://github.com/symfony/symfony/pull/369

El error 403 generando un error 500, tambien ha sido comentado en la lista de `symfony-dev`:
https://groups.google.com/d/msg/symfony-devs/5hTpWDsVEiE/qipCuRwC69IJ

Y este es un issue reciente que lo menciona, que acaba de generar actividad:
https://github.com/symfony/symfony/issues/1212
