### PR TITLE
[Fixes #81]

### DIFF
--- a/src/Desymfony/DesymfonyBundle/Entity/Ponencia.php
+++ b/src/Desymfony/DesymfonyBundle/Entity/Ponencia.php
@@ -43,13 +43,13 @@ class Ponencia
 
     /**
      * @ORM\Column(type="date")
-     * @Assert\Date()
+     * @Assert\Type(type="\DateTime")
      */
     protected $fecha;
 
     /**
      * @ORM\Column(type="time")
-     * @Assert\Time()
+     * @Assert\Type(type="\DateTime")
      */
     protected $hora;
 


### PR DESCRIPTION
El problema estaba en el Assert del modelo Ponencia. Teníamos
@Assert\Time() pero esa aserción no requiere un objeto tipo DateTime
(Time es un "alias" de Doctrine para un DateTime que no guarda el
apartado de fecha) sino una string con formato HH:MM:SS
http://symfony.com/doc/current/reference/constraints/Time.html

Quitando ese assert va, pero no es buena práctica. Así que he puesto
assert type DateTime, y ahora va.

He cambiado también el assert de Date en este sentido. El por qué iba,
no lo sé, pero por coherencia los dos deberían de ser Assert type
DateTime.
