### PR TITLE
Fixed issue #124 - Refactorizadas las plantillas que incluyen a otras plantillas

### DIFF
--- a/src/Desymfony/DesymfonyBundle/Resources/views/Default/index.html.twig
+++ b/src/Desymfony/DesymfonyBundle/Resources/views/Default/index.html.twig
@@ -11,7 +11,7 @@
 
     <ul>
     {% for ponencia in ponenciasDia1 %}
-        <li>{% include 'DesymfonyBundle:Ponencia:bloquePequeno.html.twig' with {'ponencia': ponencia } %}</li>
+        <li>{% include 'DesymfonyBundle:Ponencia:bloquePequeno.html.twig' %}</li>
     {% else %}
         <li>No hay ninguna ponencia</li>
     {% endfor %}
@@ -23,7 +23,7 @@
 
     <ul>
     {% for ponencia in ponenciasDia2 %}
-        <li>{% include 'DesymfonyBundle:Ponencia:bloquePequeno.html.twig' with {'ponencia': ponencia } %}</li>
+        <li>{% include 'DesymfonyBundle:Ponencia:bloquePequeno.html.twig' %}</li>
     {% else %}
         <li>No hay ninguna ponencia</li>
     {% endfor %}

--- a/src/Desymfony/DesymfonyBundle/Resources/views/Ponencia/bloqueGrande.html.twig
+++ b/src/Desymfony/DesymfonyBundle/Resources/views/Ponencia/bloqueGrande.html.twig
@@ -1,6 +1,6 @@
 <div class="grid_2 alpha">
   {{ ponencia.hora |  date('H:i') }} - {{ ponencia.horaFinalizacion | date('H:i') }}
-  {% include "DesymfonyBundle:Ponencia:meApunto.html.twig" with {'ponencia': ponencia } %}
+  {% include "DesymfonyBundle:Ponencia:meApunto.html.twig" %}
 </div>
 <div class="grid_10 omega">
   <a href="{{ path('ponencia', {'slug': ponencia.slug} ) }}">{{ ponencia.titulo }}</a>

--- a/src/Desymfony/DesymfonyBundle/Resources/views/Ponencia/index.html.twig
+++ b/src/Desymfony/DesymfonyBundle/Resources/views/Ponencia/index.html.twig
@@ -10,7 +10,7 @@
 
 {% for ponencia in ponenciasDia1 %}
   <div>
-  {% include 'DesymfonyBundle:Ponencia:bloqueGrande.html.twig' with {'ponencia': ponencia } %}
+  {% include 'DesymfonyBundle:Ponencia:bloqueGrande.html.twig' %}
   </div>
 {% endfor %}
 
@@ -18,7 +18,7 @@
 
 {% for ponencia in ponenciasDia2 %}
   <div>
-  {% include 'DesymfonyBundle:Ponencia:bloqueGrande.html.twig' with {'ponencia': ponencia } %}
+  {% include 'DesymfonyBundle:Ponencia:bloqueGrande.html.twig' %}
   </div>
 {% endfor %}
 {% endblock %}

--- a/src/Desymfony/DesymfonyBundle/Resources/views/Ponencia/ponencia.html.twig
+++ b/src/Desymfony/DesymfonyBundle/Resources/views/Ponencia/ponencia.html.twig
@@ -24,7 +24,7 @@
 </div>
 
 <div class="grid_3 omega">
-    {% include "DesymfonyBundle:Ponencia:meApunto.html.twig" with {'ponencia': ponencia } %}
+    {% include "DesymfonyBundle:Ponencia:meApunto.html.twig" %}
 </div>
 
 <!--


### PR DESCRIPTION
Cuando una plantilla `A` incluye a otra plantilla `B` mediante la etiqueta `{% include %}` la plantilla `B` tiene acceso automáticamente a todas las variables de la plantilla `A`.

Por eso en nuestro código no es necesario indicar lo siguiente:

``` jinja
{% include 'DesymfonyBundle:Ponencia:bloqueGrande.html.twig' with {'ponencia': ponencia } %}
```

Y bastaría con hacer lo siguiente:

``` jinja
{% include 'DesymfonyBundle:Ponencia:bloqueGrande.html.twig' %}
```
