### PR TITLE
Corregir la exportación de ponencias a formato ICS

### DIFF
--- a/src/Desymfony/DesymfonyBundle/Resources/views/Ponencia/index.ics.twig
+++ b/src/Desymfony/DesymfonyBundle/Resources/views/Ponencia/index.ics.twig
@@ -5,7 +5,7 @@ CALSCALE:GREGORIAN
 X-WR-CALNAME:JornadasSymfony2011
 X-WR-TIMEZONE:Europe/Madrid
 X-WR-CALDESC:Agenda de las Jornadas Symfony 2011 en Castellón (España)
-{% for ponencia in ponenciasTodas %}
+{% for ponencia in (ponenciasDiaUno | merge(ponenciasDiaDos)) %}
 BEGIN:VEVENT
 DTSTART:{{ponencia.fecha | date('Ymd')}}T{{ ponencia.hora | date('Hi') }}Z
 DTEND:{{((((ponencia.fecha | date('Y-m-d')) ~ " " ~ (ponencia.hora | date('H:i')))| date('U')) + ponencia.duracion * 60) | date('Ymd\\THi\\Z') }}


### PR DESCRIPTION
Al exportar a formato ICS, el bucle for de la vista index.ics.twig no estaba recorriendo el listado de ponencias de los días uno y dos
