### PR TITLE
Actualizados los DEPS 

### DIFF
--- a/deps
+++ b/deps
@@ -62,5 +62,5 @@
     git=http://github.com/doctrine/data-fixtures.git
 
 [DoctrineFixturesBundle]
-    git=http://github.com/symfony/DoctrineFixturesBundle.git
+    git=https://github.com/symfony/DoctrineFixturesBundle.git
     target=/bundles/Symfony/Bundle/DoctrineFixturesBundle

--- a/deps
+++ b/deps
@@ -1,5 +1,5 @@
 [symfony]
-    git=http://github.com/symfony/symfony.git
+    git=https://github.com/symfony/symfony.git
     version=v2.0.0
 
 [twig]
@@ -42,7 +42,7 @@
     target=/bundles/Sensio/Bundle/FrameworkExtraBundle
 
 [JMSSecurityExtraBundle]
-    git=http://github.com/schmittjoh/JMSSecurityExtraBundle.git
+    git=https://github.com/schmittjoh/JMSSecurityExtraBundle.git
     target=/bundles/JMS/SecurityExtraBundle
 
 [SensioDistributionBundle]

--- a/deps
+++ b/deps
@@ -54,7 +54,7 @@
     target=/bundles/Sensio/Bundle/GeneratorBundle
 
 [AsseticBundle]
-    git=http://github.com/symfony/AsseticBundle.git
+    git=https://github.com/symfony/AsseticBundle.git
     target=/bundles/Symfony/Bundle/AsseticBundle
     version=v1.0.0RC2
 

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -5,6 +5,7 @@
 if (!in_array(@$_SERVER['REMOTE_ADDR'], array(
     '127.0.0.1',
     '::1',
+    '10.211.1.13',
 ))) {
     header('HTTP/1.0 403 Forbidden');
     die('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');


### PR DESCRIPTION
Como comentaba marcosgdf había un error cuando se intentaba seguir el tutorial de Desymfony2011
https://github.com/desymfony/desymfony/issues/151

Llegados a un error así, puede ser muy frustrante para un "newbie" (como yo lo soy ;-)

Estos commit actualizan el archivo deps con las direcciones corregidas (algunas pasan de http a https)
